### PR TITLE
Inherit from generic interfaces.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
   - "2.6"
   - "2.7"
   - "3.4"
-matrix:
-  allow_failures:
-    - python: "2.6"
 install:
   - "pip install -r requirements.txt"
   - "python setup.py develop"

--- a/cetacean/embedded_resource_collection.py
+++ b/cetacean/embedded_resource_collection.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 
+import collections
 import cetacean
 
-class EmbeddedResourceCollection(object):
+class EmbeddedResourceCollection(collections.Sequence):
 
     """Represents a list of embedded HAL resources"""
 
@@ -21,3 +22,9 @@ class EmbeddedResourceCollection(object):
 
         """
         return cetacean.EmbeddedResource(self._document_list[index])
+
+    def __len__(self):
+        """Get the length of the collection. List a list.
+
+        """
+        return len(self._document_list)

--- a/cetacean/resource.py
+++ b/cetacean/resource.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 import sys
+import collections
 import cetacean
 
-class Resource(object):
+class Resource(collections.Mapping):
 
     """Respresents a HAL resource."""
     _attributes = None
@@ -57,12 +58,13 @@ class Resource(object):
         """
         return self._hal[attribute_name]
 
-    def get(self, *args):
-        """Access to the attributes of the resouse. Like a dictionary.
-        :returns: The value of the attribute or None.
+    def __iter__(self):
+        """Iterate over the items in the document. Like a dictionary."""
+        return self._hal.__iter__()
 
-        """
-        return self._hal.get(*args)
+    def __len__(self):
+        """The length of the document. Like a dictionary."""
+        return len(self._hal)
 
     def embedded(self, rel=None):
         """Get an embedded resource or all the embedded resources.

--- a/cetacean/resource.py
+++ b/cetacean/resource.py
@@ -80,7 +80,7 @@ class Resource(collections.Mapping):
 
         document = self.embedded()[rel]
 
-        if isinstance(document, list):
-            return cetacean.EmbeddedResourceCollection(document)
-        else:
+        if isinstance(document, collections.Mapping):
             return cetacean.EmbeddedResource(document)
+        else:
+            return cetacean.EmbeddedResourceCollection(document)

--- a/cetacean/resource.py
+++ b/cetacean/resource.py
@@ -24,7 +24,9 @@ class Resource(collections.Mapping):
         :returns: A string that is the URI in question.
 
         """
-        if sys.version_info.major == 2:
+        # if sys.version_info.major == 2:
+        # Freakin' 2.6... :fistshake:
+        if sys.version_info[0] == 2:
             rel = unicode(rel)
 
         if rel not in self.links: return None
@@ -75,7 +77,9 @@ class Resource(collections.Mapping):
         """
         if rel == None: return self._hal['_embedded']
 
-        if sys.version_info.major == 2:
+        # if sys.version_info.major == 2:
+        # Freakin' 2.6... :fistshake:
+        if sys.version_info[0] == 2:
             rel = unicode(rel)
 
         document = self.embedded()[rel]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 expects>=0.6.2
-mamba>=0.8.3
+mamba>=0.8.4

--- a/spec/acceptance_spec.py
+++ b/spec/acceptance_spec.py
@@ -53,7 +53,7 @@ with describe("Cetacean"):
 
         with it("handles plural embedded resources"):
             for index, plur in enumerate(self.subject.embedded('plural')):
-                expect(plur.get_uri('self')).to(equal('/plural/{}'.format(index + 1)))
+                expect(plur.get_uri('self')).to(equal('/plural/{0}'.format(index + 1)))
 
         with it("allows index access on plural embedded resources"):
             expect(self.subject.embedded('plural')[0].get_uri('self')).to(equal('/plural/1'))


### PR DESCRIPTION
I learned about `collections.Mapping` and `collections.Sequence` to improve the behavior of `cetacean.Resource` and `cetacean.EmbeddedResourceCollection` as `dict`s and `list`s.
